### PR TITLE
Add missing workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM php:7.2-fpm-alpine
 
+WORKDIR /var/www
+
 RUN docker-php-ext-install pdo pdo_mysql


### PR DESCRIPTION
I followed your blogpost but got error:
```
ERROR: for php  Cannot start service php: oci runtime error: container_linux.go:247: starting container process caused "chdir to cwd (\"/var/www/html\") set in config.json failed: no such file or directory"
```

This PR resolves this issue