### PR TITLE
Add --ignore-platform-reqs flag to Composer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - php
     networks:
       - laravel
+    entrypoint: ['composer', '--ignore-platform-reqs'] # Install without other php modules required
 
   npm:
     image: node:13.7


### PR DESCRIPTION
When using composer, the image may not have the required php extensions or modules to install successfully, so you have to manually pass the --ignore-platform-reqs flag each time.

Adding this to the entry point of the image means that you can just run `docker-compose run composer` without additional flags.

This avoids adding caveats to the documentation and adds to the "it just works" utility of docker.