### PR TITLE
Updated php:7.4-fpm-alpine to php:7.4.2-fpm-alpine

### DIFF
--- a/php.dockerfile
+++ b/php.dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-alpine
+FROM php:7.4.2-fpm-alpine
 
 ADD ./php/www.conf /usr/local/etc/php-fpm.d/
 


### PR DESCRIPTION
This solves a problem related with php:7.4-fpm-alpine docker image "failed to build : The command '/bin/sh -c docker-php-ext-install'"